### PR TITLE
Fix: restart game when closing modal

### DIFF
--- a/src/components/ThreeCanvas.vue
+++ b/src/components/ThreeCanvas.vue
@@ -222,6 +222,7 @@ async function endGame() {
     await fetchScore(path)
     setShowModal(true)
     setMap(path)
+    path = []
 }
 
 onLoop(({delta}) => {
@@ -396,7 +397,7 @@ export default {
     methods: {
         resetMap() {
             this.aiPath = null
-            this.path = null
+            this.humanPath = null
             setShowModal(false)
             this.setCamera()
             this.tensorToMap()


### PR DESCRIPTION
Closing the modal at the end now starts a new game as intended and clears the path previously taken.